### PR TITLE
Rename entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetryup"
-version = "0.4.0"
+version = "0.3.10"
 description = "Update dependencies and bump their version in the pyproject.toml file"
 authors = ["Mousa Zeid Baker"]
 packages = [


### PR DESCRIPTION
Hi there,

Nice tool! Looks like you forgot to rename the entrypoint in pyproject.toml as well, so the latest version on PyPi (0.3.9) does not work at the moment:

```sh
poetry run poetryup
Traceback (most recent call last):
  File ".venv/bin/poetryup", line 5, in <module>
    from poetryup.poetryup import main
ModuleNotFoundError: No module named 'poetryup.poetryup'
```

```py
#!.venv/bin/python
# -*- coding: utf-8 -*-
import re
import sys
from poetryup.poetryup import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

Kind regards,
Hampus Kraft.