### PR TITLE
Fix lock dependency not found, use normalized names when comparing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetryup"
-version = "0.5.1"
+version = "0.5.2"
 description = "Update dependencies and bump their version in the pyproject.toml file"
 authors = ["Mousa Zeid Baker"]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetryup"
-version = "0.5.2"
+version = "0.5.3"
 description = "Update dependencies and bump their version in the pyproject.toml file"
 authors = ["Mousa Zeid Baker"]
 packages = [

--- a/src/poetryup/pyproject.py
+++ b/src/poetryup/pyproject.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 import tomlkit
@@ -14,8 +14,13 @@ class Dependency:
     """A class to represent a dependency"""
 
     name: str
+    normalized_name: str = field(init=False)
     version: Union[items.String, items.InlineTable, items.Array]
     group: str
+
+    def __post_init__(self):
+        # https://www.python.org/dev/peps/pep-0503/#normalized-names
+        self.normalized_name = self.name.replace("_", "-").lower()
 
 
 class Pyproject:
@@ -97,12 +102,14 @@ class Pyproject:
         # list dependencies from pyproject and set version to lock version
         dependencies = self.list_dependencies()
         for dependency in dependencies:
-            # find corresponding lock dependency
-            name = dependency.name.lower().replace("_", "-")
-            lock_deps_iter = iter(
-                dep for dep in lock_deps if dep.name.replace("_", "-") == name
+            lock_dep = next(
+                (
+                    lock_dep
+                    for lock_dep in lock_deps
+                    if lock_dep.normalized_name == dependency.normalized_name
+                ),
+                None,
             )
-            lock_dep = next(lock_deps_iter, None)
             if lock_dep is None:
                 logging.info(
                     f"Couldn't find lock dependency for '{dependency.name}'"

--- a/src/poetryup/pyproject.py
+++ b/src/poetryup/pyproject.py
@@ -99,7 +99,7 @@ class Pyproject:
         for dependency in dependencies:
             # find corresponding lock dependency
             name = dependency.name.lower().replace("_", "-")
-            lock_dep = next(dep for dep in lock_deps.replace("_", "-") if dep.name == name)
+            lock_dep = next(dep for dep in lock_deps if dep.name.replace("_", "-") == name)
 
             constraint = ""
             if type(dependency.version) is items.String:

--- a/src/poetryup/pyproject.py
+++ b/src/poetryup/pyproject.py
@@ -99,7 +99,15 @@ class Pyproject:
         for dependency in dependencies:
             # find corresponding lock dependency
             name = dependency.name.lower().replace("_", "-")
-            lock_dep = next(dep for dep in lock_deps if dep.name.replace("_", "-") == name)
+            lock_deps_iter = iter(
+                dep for dep in lock_deps if dep.name.replace("_", "-") == name
+            )
+            lock_dep = next(lock_deps_iter, None)
+            if lock_dep is None:
+                logging.info(
+                    f"Couldn't find lock dependency for '{dependency.name}'"
+                )
+                continue
 
             constraint = ""
             if type(dependency.version) is items.String:

--- a/src/poetryup/pyproject.py
+++ b/src/poetryup/pyproject.py
@@ -99,7 +99,7 @@ class Pyproject:
         for dependency in dependencies:
             # find corresponding lock dependency
             name = dependency.name.lower().replace("_", "-")
-            lock_dep = next(dep for dep in lock_deps if dep.name == name)
+            lock_dep = next(dep for dep in lock_deps.replace("_", "-") if dep.name == name)
 
             constraint = ""
             if type(dependency.version) is items.String:

--- a/src/poetryup/pyproject.py
+++ b/src/poetryup/pyproject.py
@@ -98,7 +98,7 @@ class Pyproject:
         dependencies = self.list_dependencies()
         for dependency in dependencies:
             # find corresponding lock dependency
-            name = dependency.name.lower()
+            name = dependency.name.lower().replace("_", "-")
             lock_dep = next(dep for dep in lock_deps if dep.name == name)
 
             constraint = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,10 @@ def mock_poetry_commands(mocker: MockerFixture) -> None:
         return_value=(
             "poetryup 0.2.0 Update dependencies and bump their version in the "
             "pyproject.toml file"
-            "\n└── toml >=0.10.2,<0.11.0"
+            "\n└── toml >=0.10.2,<0.11.0\n"
+            "poetryup-extra 0.2.0 "
+            "pyproject.toml file"
+            "\n└── toml >=0.10.2,<0.11.0\n"
         ),
     )
 

--- a/tests/unit/fixtures/expected_pyproject/pyproject_with_dependency_containing_underscore_character.toml
+++ b/tests/unit/fixtures/expected_pyproject/pyproject_with_dependency_containing_underscore_character.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "test-poetryup"
+version = "0.1.0"
+description = "Test PoetryUp"
+authors = ["Mousa Zeid Baker"]
+packages = [
+    { include = "test_poetryup", from = "src" }
+]
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/MousaZeidBaker/poetryup"
+repository = "https://github.com/MousaZeidBaker/poetryup"
+keywords=[
+    "packaging",
+    "dependency",
+    "poetry",
+    "poetryup",
+]
+include = ["LICENSE"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+poetryup_extra = "^0.2.0"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+poetryup = "src.test_poetryup.test_poetryup:main"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/unit/fixtures/input_pyproject/pyproject_with_dependency_containing_underscore_character.toml
+++ b/tests/unit/fixtures/input_pyproject/pyproject_with_dependency_containing_underscore_character.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "test-poetryup"
+version = "0.1.0"
+description = "Test PoetryUp"
+authors = ["Mousa Zeid Baker"]
+packages = [
+    { include = "test_poetryup", from = "src" }
+]
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/MousaZeidBaker/poetryup"
+repository = "https://github.com/MousaZeidBaker/poetryup"
+keywords=[
+    "packaging",
+    "dependency",
+    "poetry",
+    "poetryup",
+]
+include = ["LICENSE"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+poetryup_extra = "^0.1.0"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+poetryup = "src.test_poetryup.test_poetryup:main"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Whilst PyPI normalizes package names (https://www.python.org/dev/peps/pep-0503/#normalized-names) it's possible to install packages with `_` instead of `-`, e.g. both `pip install sqlalchemy_stubs` and `pip install sqlalchemy-stubs` both work.

[This line](https://github.com/MousaZeidBaker/poetryup/blob/master/src/poetryup/pyproject.py#L45) in `pyproject.py` grabs the dependencies as specified by the user (who may be using e.g. `sqlalchemy_stubs` in `pyproject.toml`.

In this situation, [this line then errors](https://github.com/MousaZeidBaker/poetryup/blob/master/src/poetryup/pyproject.py#L102) as it doesn't find an exact match.

This small change should fix this edge case.