### PR TITLE
Update to Poetry 1.2 --sync CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ poetry shell
 
 Install dependencies
 ```shell
-poetry install --remove-untracked
+poetry install --sync
 ```
 
 Install git hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetryup"
-version = "0.12.3"
+version = "0.12.4"
 description = "Update dependencies and bump their version in the pyproject.toml file"
 authors = ["Mousa Zeid Baker"]
 packages = [


### PR DESCRIPTION
Poetry 1.2 deprecated `--remove-untracked` and replaced it with `--sync`:

- https://python-poetry.org/docs/managing-dependencies/#synchronizing-dependencies

Poetry 1.2 was released 3 months ago, so prefer using its syntax to reduce friction with new users.